### PR TITLE
Integrate log-parser job into k8s deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ kubectl create clusterrolebinding serviceaccounts-cluster-admin \
 --group=system:serviceaccounts
 ```
 
+or simply load `kubectl apply -f crb.yml`
+
 ### Creating Kubernetes resources
 Create Kubernetes resources as follows:
 ```

--- a/crb.yml
+++ b/crb.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: serviceaccounts-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts

--- a/hyperflow-engine-deployment.yml
+++ b/hyperflow-engine-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: hyperflow
-        image: hyperflowwms/hyperflow:v1.3.23
+        image: hyperflowwms/hyperflow:v1.3.25
         imagePullPolicy: Always
         env:
         - name: REDIS_URL
@@ -53,6 +53,13 @@ spec:
               cd /work_dir/ ;
               echo "Running workflow:" ;
               hflow run workflow.json ;
+              if [ -d /work_dir/logs-hf ] ; then
+                hflow-info /work_dir/workflow.json --print -f /work_dir > /work_dir/logs-hf/file_sizes.log 2>&1 ;
+                cat /work_dir/logs-hf/file_sizes.log ;
+                echo 1 > /work_dir/postprocStart ;
+              else
+                echo "Hyperflow logs not collected. Something must have gone wrong!"
+              fi ;
               echo "Workflow finished. Container is waiting for manual termination." ;
               while true; do sleep 5 ; done ;
             else

--- a/hyperflow-engine-deployment.yml
+++ b/hyperflow-engine-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: hyperflow
-        image: hyperflowwms/hyperflow:v1.3.25
+        image: hyperflowwms/hyperflow:v1.3.23
         imagePullPolicy: Always
         env:
         - name: REDIS_URL
@@ -29,8 +29,8 @@ spec:
         - name: HF_VAR_JOB_TEMPLATE_PATH
           value: "/opt/hyperflow/job-template.yaml"
         - name: HF_VAR_WORKER_CONTAINER
-          value: "hyperflowwms/soykb-workflow-worker:v1.0.10-1-g95b7caf"
-          #value: "hyperflowwms/montage-workflow-worker:v1.0.9-1-gd61c86c"
+          # value: "hyperflowwms/soykb-workflow-worker:v1.0.10-1-g95b7caf"
+          value: "hyperflowwms/montage-workflow-worker:v1.0.10"
         - name: HF_VAR_WORK_DIR
           value: "/work_dir"
         - name: HF_VAR_DEBUG

--- a/nfs-server.yml
+++ b/nfs-server.yml
@@ -38,8 +38,8 @@ spec:
           - name: workflow-data
             mountPath: "/workflow-data:shared"
       - name: workflow-data
-        image: hyperflowwms/soykb-workflow-data:hyperflow-soykb-example-f6f69d6ca3ebd9fe2458804b59b4ef71
-        #image: hyperflowwms/montage-workflow-data:montage0.25-bf0b1b4450c201ee5f549c7f473d2ef0
+        # image: hyperflowwms/soykb-workflow-data:hyperflow-soykb-example-f6f69d6ca3ebd9fe2458804b59b4ef71
+        image: hyperflowwms/montage-workflow-data:montage0.25-bf0b1b4450c201ee5f549c7f473d2ef0
         imagePullPolicy: Always
         command:
           - "/bin/sh"

--- a/parser-job.yml
+++ b/parser-job.yml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: logs-parser
+spec:
+  template:
+    metadata:
+      labels:
+        name: logs-parser
+        component: logs-parser
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: parser
+        image: hyperflowwms/log-parser:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 0 
+        command:
+          - "/bin/sh" 
+          - "-c"
+          - >
+            while ! [ -f /work_dir/postprocStart ]; do echo "Waiting for postprocStart flag to be mounted..." ; sleep 5 ; done ;
+            echo "postprocStart flag mounted: " ; ls -la /work_dir ;
+            python3 /parser.py -s /work_dir/logs-hf -d /work_dir -f /work_dir/logs-hf ;
+            tar cvfz /work_dir/logs-hf.tar.gz /work_dir/logs-hf/
+        volumeMounts:
+           - name: workflow-data
+             mountPath: "/work_dir:shared"
+      volumes:
+      - name: workflow-data
+        persistentVolumeClaim:
+          claimName: nfs
+


### PR DESCRIPTION
Zostawiona wersja hyperflowa: `1.3.23`, ponieważ nie da się spullować obrazu `1.3.24`, a obraz `1.3.25` zbugowany - joby nie odpalają się, jest napisane że insufficient CPU dla każdego utworzonego poda przez hflowa. 

Notka jeszcze, jakby chciał pan to testować - w `1.3.23` obrazie jest stara wersja hflow-info (można sprawdzić po help message tej komendy). Jest jakiś problem z npm przy normalnej próbie instalacji hflow-tools, występuje konflikt bo istnieje już hflow-info w ścieżce, pewnie o to chodzi: https://github.com/hyperflow-wms/hyperflow/blob/master/bin/hflow-info

Utworzyłem sobie ręcznie kontener z ręcznie zainstalowanym hflow-info z hflow-tools: `matplinta/hyperflow:1.0`