### PR TITLE
Always create logs directory

### DIFF
--- a/hyperflow-engine-deployment.yml
+++ b/hyperflow-engine-deployment.yml
@@ -64,9 +64,8 @@ spec:
             env | grep "HF_" ;
             while ! [ -f /work_dir/workflow.json ]; do echo "Waiting for workflow.json to be mounted..." ; done ;
             echo "Workflow data mounted: " ; ls -la /work_dir ;
+            mkdir -p /work_dir/logs-hf ;
             if [ $HF_VAR_DEBUG -eq 0 ] ; then
-              cd /work_dir/ ;
-              mkdir -p logs-hf ;
               echo "Running workflow:" ;
               hflow run workflow.json ;
               if [ "$(ls -A /work_dir/logs-hf)" ]; then


### PR DESCRIPTION
This change will avoid not-existing directory issue (https://github.com/hyperflow-wms/hyperflow-job-executor/issues/10) and restarted tasks.